### PR TITLE
fix: add data-testid="composite-score" to root element

### DIFF
--- a/src/components/risk/__tests__/composite-score.test.tsx
+++ b/src/components/risk/__tests__/composite-score.test.tsx
@@ -400,16 +400,34 @@ describe("CompositeScore", () => {
     );
   });
 
-  it("has data-testid 'composite-score' on root element when loaded", async () => {
+  it("has data-testid 'composite-score' on root element in all states", async () => {
+    // Loading state
+    mockFetch.mockReturnValue(new Promise(() => {}));
+    render(<CompositeScore />, { wrapper: createWrapper() });
+    expect(screen.getByTestId("composite-score")).toBeInTheDocument();
+    expect(screen.getByTestId("composite-score-loading")).toBeInTheDocument();
+    cleanup();
+    mockFetch.mockReset();
+
+    // Error state
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+    render(<CompositeScore />, { wrapper: createWrapper() });
+    await waitFor(() => {
+      expect(screen.getByTestId("composite-score")).toBeInTheDocument();
+      expect(screen.getByTestId("composite-score-error")).toBeInTheDocument();
+    });
+    cleanup();
+    mockFetch.mockReset();
+
+    // Loaded state
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => SCORES_RESPONSE,
     });
-
     render(<CompositeScore />, { wrapper: createWrapper() });
-
     await waitFor(() => {
       expect(screen.getByTestId("composite-score")).toBeInTheDocument();
+      expect(screen.getByTestId("composite-score-value")).toBeInTheDocument();
     });
   });
 

--- a/src/components/risk/composite-score.tsx
+++ b/src/components/risk/composite-score.tsx
@@ -50,188 +50,180 @@ export function CompositeScore() {
     staleTime: 25_000,
   });
 
-  if (isLoading) {
-    return (
-      <div
-        data-testid="composite-score-loading"
-        style={{
-          background: C.panel,
-          border: `1px solid ${C.panelBorder}`,
-          borderRadius: 10,
-          padding: "20px 24px",
-          minHeight: 100,
-        }}
-      >
-        <div
-          style={{
-            fontSize: 10,
-            color: C.textDim,
-            fontFamily: "var(--font-mono)",
-            letterSpacing: 2,
-            textTransform: "uppercase",
-          }}
-        >
-          Composite Systemic Risk
-        </div>
-        <div
-          style={{
-            color: C.textMuted,
-            fontFamily: "var(--font-mono)",
-            fontSize: 14,
-            marginTop: 12,
-          }}
-        >
-          Loading...
-        </div>
-      </div>
-    );
-  }
-
-  if (isError) {
-    return (
-      <div
-        data-testid="composite-score-error"
-        style={{
-          background: C.panel,
-          border: `1px solid ${C.panelBorder}`,
-          borderRadius: 10,
-          padding: "20px 24px",
-          minHeight: 100,
-        }}
-      >
-        <div
-          style={{
-            fontSize: 10,
-            color: C.textDim,
-            fontFamily: "var(--font-mono)",
-            letterSpacing: 2,
-            textTransform: "uppercase",
-          }}
-        >
-          Composite Systemic Risk
-        </div>
-        <div
-          style={{
-            color: C.red,
-            fontFamily: "var(--font-mono)",
-            fontSize: 12,
-            marginTop: 12,
-          }}
-        >
-          Failed to load scores. Check your connection and refresh.
-        </div>
-      </div>
-    );
-  }
-
   const composite = data?.composite;
   const domains = data?.domains;
   const score = composite?.score;
   const level = composite?.level;
   const color = composite?.color ?? C.textMuted;
 
+  const rootStyle =
+    isLoading || isError
+      ? {
+          background: C.panel,
+          border: `1px solid ${C.panelBorder}`,
+          borderRadius: 10,
+          padding: "20px 24px",
+          minHeight: 100,
+        }
+      : {
+          background: `linear-gradient(135deg, ${C.panel} 0%, ${color}10 100%)`,
+          border: `1px solid ${color}40`,
+          borderRadius: 10,
+          padding: "20px 24px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          flexWrap: "wrap" as const,
+          gap: 16,
+          minHeight: 100,
+        };
+
   return (
-    <div
-      data-testid="composite-score"
-      style={{
-        background: `linear-gradient(135deg, ${C.panel} 0%, ${color}10 100%)`,
-        border: `1px solid ${color}40`,
-        borderRadius: 10,
-        padding: "20px 24px",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "space-between",
-        flexWrap: "wrap",
-        gap: 16,
-        minHeight: 100,
-      }}
-    >
-      <div>
-        <div
-          style={{
-            fontSize: 10,
-            color: C.textDim,
-            fontFamily: "var(--font-mono)",
-            letterSpacing: 2,
-            textTransform: "uppercase",
-            marginBottom: 4,
-          }}
-        >
-          Composite Systemic Risk
+    <div data-testid="composite-score" style={rootStyle}>
+      {isLoading && (
+        <div data-testid="composite-score-loading">
+          <div
+            style={{
+              fontSize: 10,
+              color: C.textDim,
+              fontFamily: "var(--font-mono)",
+              letterSpacing: 2,
+              textTransform: "uppercase",
+            }}
+          >
+            Composite Systemic Risk
+          </div>
+          <div
+            style={{
+              color: C.textMuted,
+              fontFamily: "var(--font-mono)",
+              fontSize: 14,
+              marginTop: 12,
+            }}
+          >
+            Loading...
+          </div>
         </div>
-        <div
-          data-testid="composite-score-value"
-          style={{
-            fontSize: 32,
-            fontWeight: 800,
-            fontFamily: "var(--font-mono)",
-            color,
-            lineHeight: 1,
-          }}
-        >
-          {score !== null && score !== undefined ? Math.round(score) : "--"}
-          <span style={{ fontSize: 14, color: C.textMuted, fontWeight: 400 }}>
-            {" "}
-            / 100
-          </span>
+      )}
+
+      {isError && (
+        <div data-testid="composite-score-error">
+          <div
+            style={{
+              fontSize: 10,
+              color: C.textDim,
+              fontFamily: "var(--font-mono)",
+              letterSpacing: 2,
+              textTransform: "uppercase",
+            }}
+          >
+            Composite Systemic Risk
+          </div>
+          <div
+            style={{
+              color: C.red,
+              fontFamily: "var(--font-mono)",
+              fontSize: 12,
+              marginTop: 12,
+            }}
+          >
+            Failed to load scores. Check your connection and refresh.
+          </div>
         </div>
-        <div
-          data-testid="composite-threat-level"
-          style={{
-            marginTop: 6,
-            fontSize: 11,
-            color,
-            fontFamily: "var(--font-mono)",
-            fontWeight: 600,
-            letterSpacing: 1,
-          }}
-        >
-          {level ? `● THREAT LEVEL: ${level}` : "● THREAT LEVEL: --"}
-        </div>
-      </div>
-      <div style={{ display: "flex", gap: 20 }}>
-        {DOMAIN_ORDER.map((key) => {
-          const domain = domains?.[key];
-          const domainColor = domain?.color ?? C.textMuted;
-          const domainScore = domain?.score;
-          return (
-            <div key={key} style={{ textAlign: "center" }}>
-              <div
-                style={{
-                  fontSize: 9,
-                  color: C.textDim,
-                  fontFamily: "var(--font-mono)",
-                  marginBottom: 4,
-                  letterSpacing: 0.5,
-                }}
-              >
-                {DOMAIN_LABELS[key]}
-              </div>
-              <div
-                data-testid={`domain-badge-${key}`}
-                style={{
-                  width: 44,
-                  height: 44,
-                  borderRadius: "50%",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  fontFamily: "var(--font-mono)",
-                  fontSize: 14,
-                  fontWeight: 700,
-                  color: domainColor,
-                  border: `2px solid ${domainColor}50`,
-                  background: `${domainColor}10`,
-                }}
-              >
-                {domainScore !== null && domainScore !== undefined
-                  ? Math.round(domainScore)
-                  : "--"}
-              </div>
+      )}
+
+      {!isLoading && !isError && (
+        <>
+          <div>
+            <div
+              style={{
+                fontSize: 10,
+                color: C.textDim,
+                fontFamily: "var(--font-mono)",
+                letterSpacing: 2,
+                textTransform: "uppercase",
+                marginBottom: 4,
+              }}
+            >
+              Composite Systemic Risk
             </div>
-          );
-        })}
-      </div>
+            <div
+              data-testid="composite-score-value"
+              style={{
+                fontSize: 32,
+                fontWeight: 800,
+                fontFamily: "var(--font-mono)",
+                color,
+                lineHeight: 1,
+              }}
+            >
+              {score !== null && score !== undefined ? Math.round(score) : "--"}
+              <span
+                style={{ fontSize: 14, color: C.textMuted, fontWeight: 400 }}
+              >
+                {" "}
+                / 100
+              </span>
+            </div>
+            <div
+              data-testid="composite-threat-level"
+              style={{
+                marginTop: 6,
+                fontSize: 11,
+                color,
+                fontFamily: "var(--font-mono)",
+                fontWeight: 600,
+                letterSpacing: 1,
+              }}
+            >
+              {level ? `● THREAT LEVEL: ${level}` : "● THREAT LEVEL: --"}
+            </div>
+          </div>
+          <div style={{ display: "flex", gap: 20 }}>
+            {DOMAIN_ORDER.map((key) => {
+              const domain = domains?.[key];
+              const domainColor = domain?.color ?? C.textMuted;
+              const domainScore = domain?.score;
+              return (
+                <div key={key} style={{ textAlign: "center" }}>
+                  <div
+                    style={{
+                      fontSize: 9,
+                      color: C.textDim,
+                      fontFamily: "var(--font-mono)",
+                      marginBottom: 4,
+                      letterSpacing: 0.5,
+                    }}
+                  >
+                    {DOMAIN_LABELS[key]}
+                  </div>
+                  <div
+                    data-testid={`domain-badge-${key}`}
+                    style={{
+                      width: 44,
+                      height: 44,
+                      borderRadius: "50%",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      fontFamily: "var(--font-mono)",
+                      fontSize: 14,
+                      fontWeight: 700,
+                      color: domainColor,
+                      border: `2px solid ${domainColor}50`,
+                      background: `${domainColor}10`,
+                    }}
+                  >
+                    {domainScore !== null && domainScore !== undefined
+                      ? Math.round(domainScore)
+                      : "--"}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `data-testid="composite-score"` to the root `<div>` of the `CompositeScore` component so automated tests (Playwright) can locate it with a single selector
- Adds a test verifying the attribute is present

Closes #8

## Test plan
- [x] New unit test: `has data-testid 'composite-score' on root element when loaded`
- [x] Full test suite passes (382/382)