### PR TITLE
fix: rename "AI / Tech Concentration" to "AI/Tech Concentration", add domain-specific testids

### DIFF
--- a/src/components/risk/__tests__/sector-panel.test.tsx
+++ b/src/components/risk/__tests__/sector-panel.test.tsx
@@ -224,7 +224,7 @@ describe("SectorPanel", () => {
     });
 
     await waitFor(() => {
-      const panel = screen.getByTestId("sector-panel");
+      const panel = screen.getByTestId("sector-panel-private_credit");
       expect(panel.style.borderColor).toContain("249, 115, 22");
     });
   });

--- a/src/components/risk/__tests__/sector-panels.test.tsx
+++ b/src/components/risk/__tests__/sector-panels.test.tsx
@@ -54,17 +54,23 @@ describe("SectorPanels", () => {
     render(<SectorPanels />, { wrapper: createWrapper() });
 
     expect(screen.getByText("Private Credit Stress")).toBeInTheDocument();
-    expect(screen.getByText("AI / Tech Concentration")).toBeInTheDocument();
+    expect(screen.getByText("AI/Tech Concentration")).toBeInTheDocument();
     expect(screen.getByText("Energy & Geopolitical")).toBeInTheDocument();
     expect(screen.getByText("Cross-Domain Contagion")).toBeInTheDocument();
   });
 
-  it("renders four sector panels", async () => {
+  it("renders four sector panels with domain-specific testids", async () => {
     mockAllFetches();
     render(<SectorPanels />, { wrapper: createWrapper() });
 
-    const panels = screen.getAllByTestId("sector-panel");
-    expect(panels).toHaveLength(4);
+    expect(
+      screen.getByTestId("sector-panel-private_credit"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("sector-panel-ai_concentration"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("sector-panel-energy_geo")).toBeInTheDocument();
+    expect(screen.getByTestId("sector-panel-contagion")).toBeInTheDocument();
   });
 
   it("first panel (Private Credit) is expanded by default", async () => {

--- a/src/components/risk/sector-panel.tsx
+++ b/src/components/risk/sector-panel.tsx
@@ -104,7 +104,7 @@ export function SectorPanel({
 
   return (
     <div
-      data-testid="sector-panel"
+      data-testid={`sector-panel-${domain.scoreKey}`}
       style={{
         background: C.panel,
         border: `1px solid ${expanded ? `${domain.color}60` : C.panelBorder}`,

--- a/src/lib/__tests__/domain-config.test.ts
+++ b/src/lib/__tests__/domain-config.test.ts
@@ -10,8 +10,8 @@ describe("DOMAINS configuration", () => {
     expect(DOMAINS[0].name).toBe("Private Credit Stress");
   });
 
-  it("has AI / Tech Concentration as second domain", () => {
-    expect(DOMAINS[1].name).toBe("AI / Tech Concentration");
+  it("has AI/Tech Concentration as second domain", () => {
+    expect(DOMAINS[1].name).toBe("AI/Tech Concentration");
   });
 
   it("has Energy & Geopolitical as third domain", () => {

--- a/src/lib/domain-config.ts
+++ b/src/lib/domain-config.ts
@@ -30,7 +30,7 @@ export const DOMAINS: DomainConfig[] = [
     ],
   },
   {
-    name: "AI / Tech Concentration",
+    name: "AI/Tech Concentration",
     description: "Mag-10 weight, SPY vs RSP spread, sector momentum",
     icon: "cpu",
     color: "#a855f7",


### PR DESCRIPTION
## Summary
- Removes extra spaces around slash: "AI / Tech Concentration" → "AI/Tech Concentration"
- Replaces generic `data-testid="sector-panel"` with domain-specific `data-testid="sector-panel-{scoreKey}"` (e.g., `sector-panel-ai_concentration`) for reliable Playwright targeting

Closes #10

## Test plan
- [x] Updated domain-config test to expect "AI/Tech Concentration"
- [x] Updated sector-panels test to expect new display name
- [x] Added test asserting all 4 domain-specific testids render
- [x] Updated sector-panel test for domain-specific testid
- [x] Full suite passes (382/382)