### PR TITLE
fix: make CONTAGION THRESHOLD label discoverable by Playwright

### DIFF
--- a/src/components/risk/correlation-chart.tsx
+++ b/src/components/risk/correlation-chart.tsx
@@ -231,12 +231,22 @@ export function CorrelationChart() {
                 y={CONTAGION_THRESHOLD}
                 stroke={C.red}
                 strokeDasharray="4 4"
-                label={{
-                  value: "CONTAGION THRESHOLD",
-                  position: "right",
-                  fill: C.red,
-                  fontSize: 8,
-                }}
+                label={({
+                  viewBox,
+                }: {
+                  viewBox: { x?: number; y?: number; width?: number };
+                }) => (
+                  <text
+                    data-testid="contagion-threshold-label"
+                    x={(viewBox.x ?? 0) + (viewBox.width ?? 0) + 4}
+                    y={(viewBox.y ?? 0) - 4}
+                    fill={C.red}
+                    fontSize={8}
+                    textAnchor="end"
+                  >
+                    CONTAGION THRESHOLD
+                  </text>
+                )}
               />
               <ReferenceLine
                 y={0}


### PR DESCRIPTION
## Summary
- Replaces Recharts `ReferenceLine` label object with a custom label component rendering a standard `<text>` SVG element
- Adds `data-testid="contagion-threshold-label"` to the label element
- Label is now discoverable by both `page.locator('text=CONTAGION THRESHOLD')` and `[data-testid="contagion-threshold-label"]`

Closes #9

## Test plan
- [x] Full unit test suite passes (382/382)
- [x] Playwright: `data-testid="contagion-threshold-label"` found and contains correct text
- [x] Playwright: `text=CONTAGION THRESHOLD` selector now matches (count: 1)
- [x] Playwright: Correlation chart renders with rho value and threshold line
- [x] Visual verification via screenshot