### PR TITLE
fix: show -- instead of 0/LOW when domain score is null

### DIFF
--- a/src/components/risk/__tests__/threat-gauge.test.tsx
+++ b/src/components/risk/__tests__/threat-gauge.test.tsx
@@ -79,4 +79,21 @@ describe("ThreatGauge", () => {
     expect(screen.getByTestId("gauge-score")).toHaveTextContent("100");
     expect(screen.getByTestId("gauge-label")).toHaveTextContent("CRITICAL");
   });
+
+  it("renders -- when score is null", () => {
+    render(<ThreatGauge score={null} color="#475569" />);
+    expect(screen.getByTestId("gauge-score")).toHaveTextContent("--");
+  });
+
+  it("does not render a threat level label when score is null", () => {
+    render(<ThreatGauge score={null} color="#475569" />);
+    expect(screen.getByTestId("gauge-label")).toHaveTextContent("");
+  });
+
+  it("does not render score arc when score is null", () => {
+    const { container } = render(<ThreatGauge score={null} color="#475569" />);
+    expect(
+      container.querySelector("[data-testid='gauge-arc']"),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/risk/sector-panel.tsx
+++ b/src/components/risk/sector-panel.tsx
@@ -75,7 +75,7 @@ export function SectorPanel({
   });
 
   const domainScore = scores?.domains[domain.scoreKey];
-  const score = domainScore?.score ?? 0;
+  const score = domainScore?.score ?? null;
   const scoreColor = domainScore?.color ?? domain.color;
 
   const { data: tickerData } = useQuery<Record<string, TimeSeriesRow[]>>({

--- a/src/components/risk/threat-gauge.tsx
+++ b/src/components/risk/threat-gauge.tsx
@@ -2,7 +2,7 @@ import { useId } from "react";
 import { threatLabel } from "@/lib/theme";
 
 interface ThreatGaugeProps {
-  score: number;
+  score: number | null;
   color: string;
   size?: number;
 }
@@ -10,9 +10,11 @@ interface ThreatGaugeProps {
 /**
  * Semicircular arc gauge displaying a threat score (0-100).
  * Renders an SVG arc from bottom-left to bottom-right (270 degrees sweep).
+ * When score is null, displays "--" with no threat level label.
  */
 export function ThreatGauge({ score, color, size = 90 }: ThreatGaugeProps) {
-  const label = threatLabel(score);
+  const hasScore = score !== null;
+  const label = hasScore ? threatLabel(score) : "";
   const cx = size / 2;
   const cy = size / 2;
   const r = size * 0.38;
@@ -21,7 +23,9 @@ export function ThreatGauge({ score, color, size = 90 }: ThreatGaugeProps) {
   // Arc spans 270 degrees, starting at 135 degrees (bottom-left)
   const startAngle = 135;
   const totalSweep = 270;
-  const scoreAngle = (Math.min(Math.max(score, 0), 100) / 100) * totalSweep;
+  const scoreAngle = hasScore
+    ? (Math.min(Math.max(score, 0), 100) / 100) * totalSweep
+    : 0;
 
   const uniqueId = useId();
   const filterId = `glow-${uniqueId}`;
@@ -80,7 +84,7 @@ export function ThreatGauge({ score, color, size = 90 }: ThreatGaugeProps) {
         fontSize={size * 0.24}
         fontWeight={700}
       >
-        {Math.round(score)}
+        {hasScore ? Math.round(score) : "--"}
       </text>
 
       {/* Level label */}


### PR DESCRIPTION
Closes #18

## Summary

- `ThreatGauge` now accepts `score: number | null` and renders `--` with no threat level label when null
- `SectorPanel` passes `null` through to the gauge instead of falling back to `0`

## Test plan

- [ ] `pnpm test` -- 468 tests pass (3 new for null score handling)
- [ ] With Docker stack running on a weekend (or fresh deploy with no data), sector panels for domains without data show `--` instead of `0 / LOW`