### PR TITLE
feat: add project Makefile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ go test -tags=integration -count=1 ./...  # Integration tests (requires Docker)
 cd services/correlation
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-python -m pytest -v -k "not integration and not dispatch_wiring and not e2e"  # Unit tests only
+python -m pytest -v -k "not integration and not e2e"  # Unit tests only
 python -m pytest -v                                                # Full suite (requires DATABASE_URL)
 ```
 
@@ -233,7 +233,7 @@ Cost optimization — Finnhub (free) handles all high-frequency polling, Valyu (
 
 - Unit tests use pure functions (`score_*_from_values`)
 - Integration tests require `DATABASE_URL` pointing to running TimescaleDB
-- Skip tags: `integration`, `dispatch_wiring`
+- Skip tags: `integration`
 
 **E2E**:
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ py-setup: ## Create venv and install Python deps
 
 py-test: ## Run Python unit tests only
 	cd services/correlation && . .venv/bin/activate && \
-		python -m pytest -v -k "not integration and not dispatch_wiring and not e2e"
+		python -m pytest -v -k "not integration and not e2e"
 
 py-test-all: ## Run full Python test suite (requires DATABASE_URL)
 	cd services/correlation && . .venv/bin/activate && \

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ go test -tags=integration -count=1 ./...  # Integration tests (requires Docker)
 cd services/correlation
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-python -m pytest -v -k "not integration and not dispatch_wiring"  # Unit tests
+python -m pytest -v -k "not integration"  # Unit tests
 python -m pytest -v                                                # Full suite (requires DATABASE_URL)
 ```
 


### PR DESCRIPTION
## Summary

- Adds a top-level Makefile with targets spanning all three services (TypeScript/Next.js, Go ingestion, Python correlation)
- Covers install, dev, build, lint, unit tests, and watch mode for the frontend
- Includes `go-vet`, `go-test`, and `go-test-integration` for the ingestion service
- Includes `py-setup`, `py-test`, and `py-test-all` for the correlation service
- Separates E2E targets: `e2e` (Playwright), `e2e-go` (Go), `e2e-bash` (bash scripts)
- Docker targets use `--build` to ensure images are rebuilt on changes
- Composite targets: `test-all` (all unit tests) and `check` (lint + all unit tests)
- Self-documenting `make help` output

## Test plan

- [x] `make help` displays all 22 targets
- [x] `make test` runs Vitest
- [x] `make go-test` runs Go unit tests
- [x] `make py-test` runs Python unit tests
- [x] `make docker-up` builds and starts all services