### PR TITLE
Improve bash E2E test isolation and cleanup (#42)

### DIFF
--- a/tests/e2e-alerting.sh
+++ b/tests/e2e-alerting.sh
@@ -11,7 +11,7 @@ set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-DC="docker compose -p frm-e2e -f ${PROJECT_DIR}/docker-compose.yml"
+DC=(docker compose -p frm-e2e -f "${PROJECT_DIR}/docker-compose.yml")
 
 DB_USER="risk"
 DB_NAME="riskmonitor"
@@ -26,7 +26,7 @@ cleanup() {
     if [ -n "${WEBHOOK_PID}" ] && kill -0 "${WEBHOOK_PID}" 2>/dev/null; then
         kill "${WEBHOOK_PID}" 2>/dev/null || true
     fi
-    ${DC} down -v --remove-orphans 2>/dev/null || true
+    "${DC[@]}" down -v --remove-orphans 2>/dev/null || true
     rm -f "${WEBHOOK_LOG}" "${ALERT_CONFIG}"
     if [ -n "${E2E_VENV:-}" ] && [ -d "${E2E_VENV:-}" ]; then
         rm -rf "${E2E_VENV}"
@@ -53,7 +53,7 @@ require_cmd jq
 require_cmd python3
 
 psql_cmd() {
-    ${DC} exec -T timescaledb \
+    "${DC[@]}" exec -T timescaledb \
         psql -U "${DB_USER}" -d "${DB_NAME}" "$@"
 }
 
@@ -131,7 +131,7 @@ echo "Webhook URL: ${WEBHOOK_URL}"
 # -------------------------------------------------------------------
 echo ""
 echo "--- Starting TimescaleDB ---"
-${DC} up -d timescaledb
+"${DC[@]}" up -d timescaledb
 
 echo "--- Waiting for TimescaleDB to be healthy ---"
 for i in $(seq 1 60); do
@@ -242,7 +242,8 @@ CORRELATION_DIR="${PROJECT_DIR}/services/correlation"
 # Reuse the correlation service venv if available (has all needed packages).
 # Fall back to a disposable temp venv otherwise.
 CORR_VENV="${CORRELATION_DIR}/.venv"
-if [ -f "${CORR_VENV}/bin/activate" ]; then
+if [ -f "${CORR_VENV}/bin/activate" ] \
+   && (source "${CORR_VENV}/bin/activate" && python3 -c 'import psycopg2, yaml, requests' 2>/dev/null); then
     echo "  Using existing venv at ${CORR_VENV}"
     source "${CORR_VENV}/bin/activate"
 else
@@ -398,7 +399,7 @@ assert_eq "vix_spike re-fired after cooldown expiry" "2" "${VIX_AFTER_EXPIRY}"
 # -------------------------------------------------------------------
 echo ""
 echo "--- Starting app service for API tests ---"
-${DC} up -d app
+"${DC[@]}" up -d app
 
 echo "--- Waiting for app service ---"
 for i in $(seq 1 90); do

--- a/tests/e2e-alerting.sh
+++ b/tests/e2e-alerting.sh
@@ -247,11 +247,11 @@ if [ -f "${CORR_VENV}/bin/activate" ] \
     echo "  Using existing venv at ${CORR_VENV}"
     source "${CORR_VENV}/bin/activate"
 else
-    echo "  Creating temporary venv (correlation .venv not found)"
+    echo "  Creating temporary venv (correlation .venv missing or incomplete)"
     E2E_VENV=$(mktemp -d /tmp/e2e-alerting-venv.XXXXXX)
     python3 -m venv "${E2E_VENV}"
     source "${E2E_VENV}/bin/activate"
-    pip install -q psycopg2-binary pyyaml requests 2>/dev/null
+    pip install -q psycopg2-binary pyyaml requests
 fi
 
 # Run evaluate_rules 3 times to build consecutive count for composite_critical.

--- a/tests/e2e-alerting.sh
+++ b/tests/e2e-alerting.sh
@@ -239,11 +239,19 @@ echo "--- Running alert evaluation (iteration 1) ---"
 DB_URL="postgres://${DB_USER}:${DB_PASSWORD}@localhost:5432/${DB_NAME}"
 CORRELATION_DIR="${PROJECT_DIR}/services/correlation"
 
-# Set up a virtual environment for Python dependencies
-E2E_VENV=$(mktemp -d /tmp/e2e-alerting-venv.XXXXXX)
-python3 -m venv "${E2E_VENV}"
-source "${E2E_VENV}/bin/activate"
-pip install -q psycopg2-binary pyyaml requests 2>/dev/null
+# Reuse the correlation service venv if available (has all needed packages).
+# Fall back to a disposable temp venv otherwise.
+CORR_VENV="${CORRELATION_DIR}/.venv"
+if [ -f "${CORR_VENV}/bin/activate" ]; then
+    echo "  Using existing venv at ${CORR_VENV}"
+    source "${CORR_VENV}/bin/activate"
+else
+    echo "  Creating temporary venv (correlation .venv not found)"
+    E2E_VENV=$(mktemp -d /tmp/e2e-alerting-venv.XXXXXX)
+    python3 -m venv "${E2E_VENV}"
+    source "${E2E_VENV}/bin/activate"
+    pip install -q psycopg2-binary pyyaml requests 2>/dev/null
+fi
 
 # Run evaluate_rules 3 times to build consecutive count for composite_critical.
 # Insert a new SCORE_COMPOSITE reading before each iteration so the value changes

--- a/tests/e2e-alerting.sh
+++ b/tests/e2e-alerting.sh
@@ -11,6 +11,7 @@ set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DC="docker compose -p frm-e2e -f ${PROJECT_DIR}/docker-compose.yml"
 
 DB_USER="risk"
 DB_NAME="riskmonitor"
@@ -25,7 +26,7 @@ cleanup() {
     if [ -n "${WEBHOOK_PID}" ] && kill -0 "${WEBHOOK_PID}" 2>/dev/null; then
         kill "${WEBHOOK_PID}" 2>/dev/null || true
     fi
-    docker compose -f "${PROJECT_DIR}/docker-compose.yml" down -v --remove-orphans 2>/dev/null || true
+    ${DC} down -v --remove-orphans 2>/dev/null || true
     rm -f "${WEBHOOK_LOG}" "${ALERT_CONFIG}"
     if [ -n "${E2E_VENV:-}" ] && [ -d "${E2E_VENV:-}" ]; then
         rm -rf "${E2E_VENV}"
@@ -52,7 +53,7 @@ require_cmd jq
 require_cmd python3
 
 psql_cmd() {
-    docker compose -f "${PROJECT_DIR}/docker-compose.yml" exec -T timescaledb \
+    ${DC} exec -T timescaledb \
         psql -U "${DB_USER}" -d "${DB_NAME}" "$@"
 }
 
@@ -130,7 +131,7 @@ echo "Webhook URL: ${WEBHOOK_URL}"
 # -------------------------------------------------------------------
 echo ""
 echo "--- Starting TimescaleDB ---"
-docker compose -f "${PROJECT_DIR}/docker-compose.yml" up -d timescaledb
+${DC} up -d timescaledb
 
 echo "--- Waiting for TimescaleDB to be healthy ---"
 for i in $(seq 1 60); do
@@ -389,7 +390,7 @@ assert_eq "vix_spike re-fired after cooldown expiry" "2" "${VIX_AFTER_EXPIRY}"
 # -------------------------------------------------------------------
 echo ""
 echo "--- Starting app service for API tests ---"
-docker compose -f "${PROJECT_DIR}/docker-compose.yml" up -d app
+${DC} up -d app
 
 echo "--- Waiting for app service ---"
 for i in $(seq 1 90); do

--- a/tests/e2e-correlation.sh
+++ b/tests/e2e-correlation.sh
@@ -15,10 +15,11 @@ set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DC="docker compose -p frm-e2e -f ${PROJECT_DIR}/docker-compose.yml"
 
 cleanup() {
     echo "--- Cleaning up Docker services ---"
-    docker compose -f "${PROJECT_DIR}/docker-compose.yml" down -v --remove-orphans 2>/dev/null || true
+    ${DC} down -v --remove-orphans 2>/dev/null || true
 }
 trap cleanup EXIT
 
@@ -46,11 +47,11 @@ echo ""
 # 1. Start TimescaleDB
 # ---------------------------------------------------------------------------
 echo "--- Starting TimescaleDB ---"
-docker compose -f "${PROJECT_DIR}/docker-compose.yml" up -d timescaledb
+${DC} up -d timescaledb
 
 echo "--- Waiting for TimescaleDB to be healthy ---"
 for i in $(seq 1 60); do
-    if docker compose -f "${PROJECT_DIR}/docker-compose.yml" exec -T timescaledb \
+    if ${DC} exec -T timescaledb \
         psql -U risk -d riskmonitor -t -c "SELECT 1 FROM time_series LIMIT 0;" >/dev/null 2>&1; then
         echo "TimescaleDB is ready (attempt ${i})"
         break
@@ -106,12 +107,12 @@ done
 SEED_SQL="${SEED_SQL}
 ON CONFLICT (time, ticker) DO UPDATE SET value = EXCLUDED.value, source = EXCLUDED.source;"
 
-docker compose -f "${PROJECT_DIR}/docker-compose.yml" exec -T timescaledb \
+${DC} exec -T timescaledb \
     psql -U risk -d riskmonitor -c "${SEED_SQL}"
 echo "PASS: Seeded 450 rows (10 tickers x 45 days)"
 
 # Verify seeded data count
-SEED_COUNT=$(docker compose -f "${PROJECT_DIR}/docker-compose.yml" exec -T timescaledb \
+SEED_COUNT=$(${DC} exec -T timescaledb \
     psql -U risk -d riskmonitor -t -c \
     "SELECT COUNT(*) FROM time_series WHERE source = 'finnhub';" 2>/dev/null | tr -d '[:space:]')
 
@@ -127,12 +128,12 @@ echo "PASS: ${SEED_COUNT} raw price rows in database"
 echo "--- Starting correlation service (COMPUTE_INTERVAL_SECONDS=5) ---"
 
 # Override the compute interval so the service runs quickly
-COMPUTE_INTERVAL_SECONDS=5 docker compose -f "${PROJECT_DIR}/docker-compose.yml" up -d correlation
+COMPUTE_INTERVAL_SECONDS=5 ${DC} up -d correlation
 
 echo "--- Waiting for domain indices to appear in time_series ---"
 INDEX_TICKERS=("IDX_PRIVATE_CREDIT" "IDX_AI_TECH" "IDX_ENERGY")
 for attempt in $(seq 1 90); do
-    IDX_COUNT=$(docker compose -f "${PROJECT_DIR}/docker-compose.yml" exec -T timescaledb \
+    IDX_COUNT=$(${DC} exec -T timescaledb \
         psql -U risk -d riskmonitor -t -c \
         "SELECT COUNT(DISTINCT ticker) FROM time_series WHERE ticker IN ('IDX_PRIVATE_CREDIT', 'IDX_AI_TECH', 'IDX_ENERGY');" 2>/dev/null | tr -d '[:space:]')
 
@@ -143,7 +144,7 @@ for attempt in $(seq 1 90); do
     if [ "$attempt" -eq 90 ]; then
         echo "FAIL: Timed out waiting for domain indices (found ${IDX_COUNT}/3)" >&2
         # Show correlation service logs for debugging
-        docker compose -f "${PROJECT_DIR}/docker-compose.yml" logs correlation 2>&1 | tail -30
+        ${DC} logs correlation 2>&1 | tail -30
         exit 1
     fi
     sleep 2
@@ -155,7 +156,7 @@ done
 echo ""
 echo "--- Verifying domain indices ---"
 for idx_ticker in "${INDEX_TICKERS[@]}"; do
-    COUNT=$(docker compose -f "${PROJECT_DIR}/docker-compose.yml" exec -T timescaledb \
+    COUNT=$(${DC} exec -T timescaledb \
         psql -U risk -d riskmonitor -t -c \
         "SELECT COUNT(*) FROM time_series WHERE ticker = '${idx_ticker}';" 2>/dev/null | tr -d '[:space:]')
 
@@ -173,7 +174,7 @@ echo ""
 echo "--- Waiting for correlation values to appear ---"
 CORR_TICKERS=("CORR_CREDIT_TECH" "CORR_CREDIT_ENERGY" "CORR_TECH_ENERGY")
 for attempt in $(seq 1 90); do
-    CORR_COUNT=$(docker compose -f "${PROJECT_DIR}/docker-compose.yml" exec -T timescaledb \
+    CORR_COUNT=$(${DC} exec -T timescaledb \
         psql -U risk -d riskmonitor -t -c \
         "SELECT COUNT(DISTINCT ticker) FROM time_series WHERE ticker IN ('CORR_CREDIT_TECH', 'CORR_CREDIT_ENERGY', 'CORR_TECH_ENERGY');" 2>/dev/null | tr -d '[:space:]')
 
@@ -183,7 +184,7 @@ for attempt in $(seq 1 90); do
     fi
     if [ "$attempt" -eq 90 ]; then
         echo "FAIL: Timed out waiting for correlations (found ${CORR_COUNT}/3)" >&2
-        docker compose -f "${PROJECT_DIR}/docker-compose.yml" logs correlation 2>&1 | tail -30
+        ${DC} logs correlation 2>&1 | tail -30
         exit 1
     fi
     sleep 2
@@ -191,7 +192,7 @@ done
 
 # Verify each correlation ticker
 for corr_ticker in "${CORR_TICKERS[@]}"; do
-    COUNT=$(docker compose -f "${PROJECT_DIR}/docker-compose.yml" exec -T timescaledb \
+    COUNT=$(${DC} exec -T timescaledb \
         psql -U risk -d riskmonitor -t -c \
         "SELECT COUNT(*) FROM time_series WHERE ticker = '${corr_ticker}';" 2>/dev/null | tr -d '[:space:]')
 
@@ -207,7 +208,7 @@ done
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- Verifying correlation values are in [-1, 1] ---"
-OUT_OF_RANGE=$(docker compose -f "${PROJECT_DIR}/docker-compose.yml" exec -T timescaledb \
+OUT_OF_RANGE=$(${DC} exec -T timescaledb \
     psql -U risk -d riskmonitor -t -c \
     "SELECT COUNT(*) FROM time_series WHERE ticker LIKE 'CORR_%' AND (value < -1.0 OR value > 1.0);" 2>/dev/null | tr -d '[:space:]')
 
@@ -222,7 +223,7 @@ echo "PASS: All correlation values are in [-1, 1]"
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- Starting app service ---"
-docker compose -f "${PROJECT_DIR}/docker-compose.yml" up -d app
+${DC} up -d app
 
 echo "--- Waiting for app service to be ready ---"
 for i in $(seq 1 90); do
@@ -232,7 +233,7 @@ for i in $(seq 1 90); do
     fi
     if [ "$i" -eq 90 ]; then
         echo "FAIL: App service did not become ready in 90 seconds" >&2
-        docker compose -f "${PROJECT_DIR}/docker-compose.yml" logs app 2>&1 | tail -30
+        ${DC} logs app 2>&1 | tail -30
         exit 1
     fi
     sleep 1

--- a/tests/e2e-correlation.sh
+++ b/tests/e2e-correlation.sh
@@ -15,11 +15,11 @@ set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-DC="docker compose -p frm-e2e -f ${PROJECT_DIR}/docker-compose.yml"
+DC=(docker compose -p frm-e2e -f "${PROJECT_DIR}/docker-compose.yml")
 
 cleanup() {
     echo "--- Cleaning up Docker services ---"
-    ${DC} down -v --remove-orphans 2>/dev/null || true
+    "${DC[@]}" down -v --remove-orphans 2>/dev/null || true
 }
 trap cleanup EXIT
 
@@ -47,11 +47,11 @@ echo ""
 # 1. Start TimescaleDB
 # ---------------------------------------------------------------------------
 echo "--- Starting TimescaleDB ---"
-${DC} up -d timescaledb
+"${DC[@]}" up -d timescaledb
 
 echo "--- Waiting for TimescaleDB to be healthy ---"
 for i in $(seq 1 60); do
-    if ${DC} exec -T timescaledb \
+    if "${DC[@]}" exec -T timescaledb \
         psql -U risk -d riskmonitor -t -c "SELECT 1 FROM time_series LIMIT 0;" >/dev/null 2>&1; then
         echo "TimescaleDB is ready (attempt ${i})"
         break
@@ -107,12 +107,12 @@ done
 SEED_SQL="${SEED_SQL}
 ON CONFLICT (time, ticker) DO UPDATE SET value = EXCLUDED.value, source = EXCLUDED.source;"
 
-${DC} exec -T timescaledb \
+"${DC[@]}" exec -T timescaledb \
     psql -U risk -d riskmonitor -c "${SEED_SQL}"
 echo "PASS: Seeded 450 rows (10 tickers x 45 days)"
 
 # Verify seeded data count
-SEED_COUNT=$(${DC} exec -T timescaledb \
+SEED_COUNT=$("${DC[@]}" exec -T timescaledb \
     psql -U risk -d riskmonitor -t -c \
     "SELECT COUNT(*) FROM time_series WHERE source = 'finnhub';" 2>/dev/null | tr -d '[:space:]')
 
@@ -128,12 +128,12 @@ echo "PASS: ${SEED_COUNT} raw price rows in database"
 echo "--- Starting correlation service (COMPUTE_INTERVAL_SECONDS=5) ---"
 
 # Override the compute interval so the service runs quickly
-COMPUTE_INTERVAL_SECONDS=5 ${DC} up -d correlation
+COMPUTE_INTERVAL_SECONDS=5 "${DC[@]}" up -d correlation
 
 echo "--- Waiting for domain indices to appear in time_series ---"
 INDEX_TICKERS=("IDX_PRIVATE_CREDIT" "IDX_AI_TECH" "IDX_ENERGY")
 for attempt in $(seq 1 90); do
-    IDX_COUNT=$(${DC} exec -T timescaledb \
+    IDX_COUNT=$("${DC[@]}" exec -T timescaledb \
         psql -U risk -d riskmonitor -t -c \
         "SELECT COUNT(DISTINCT ticker) FROM time_series WHERE ticker IN ('IDX_PRIVATE_CREDIT', 'IDX_AI_TECH', 'IDX_ENERGY');" 2>/dev/null | tr -d '[:space:]')
 
@@ -144,7 +144,7 @@ for attempt in $(seq 1 90); do
     if [ "$attempt" -eq 90 ]; then
         echo "FAIL: Timed out waiting for domain indices (found ${IDX_COUNT}/3)" >&2
         # Show correlation service logs for debugging
-        ${DC} logs correlation 2>&1 | tail -30
+        "${DC[@]}" logs correlation 2>&1 | tail -30
         exit 1
     fi
     sleep 2
@@ -156,7 +156,7 @@ done
 echo ""
 echo "--- Verifying domain indices ---"
 for idx_ticker in "${INDEX_TICKERS[@]}"; do
-    COUNT=$(${DC} exec -T timescaledb \
+    COUNT=$("${DC[@]}" exec -T timescaledb \
         psql -U risk -d riskmonitor -t -c \
         "SELECT COUNT(*) FROM time_series WHERE ticker = '${idx_ticker}';" 2>/dev/null | tr -d '[:space:]')
 
@@ -174,7 +174,7 @@ echo ""
 echo "--- Waiting for correlation values to appear ---"
 CORR_TICKERS=("CORR_CREDIT_TECH" "CORR_CREDIT_ENERGY" "CORR_TECH_ENERGY")
 for attempt in $(seq 1 90); do
-    CORR_COUNT=$(${DC} exec -T timescaledb \
+    CORR_COUNT=$("${DC[@]}" exec -T timescaledb \
         psql -U risk -d riskmonitor -t -c \
         "SELECT COUNT(DISTINCT ticker) FROM time_series WHERE ticker IN ('CORR_CREDIT_TECH', 'CORR_CREDIT_ENERGY', 'CORR_TECH_ENERGY');" 2>/dev/null | tr -d '[:space:]')
 
@@ -184,7 +184,7 @@ for attempt in $(seq 1 90); do
     fi
     if [ "$attempt" -eq 90 ]; then
         echo "FAIL: Timed out waiting for correlations (found ${CORR_COUNT}/3)" >&2
-        ${DC} logs correlation 2>&1 | tail -30
+        "${DC[@]}" logs correlation 2>&1 | tail -30
         exit 1
     fi
     sleep 2
@@ -192,7 +192,7 @@ done
 
 # Verify each correlation ticker
 for corr_ticker in "${CORR_TICKERS[@]}"; do
-    COUNT=$(${DC} exec -T timescaledb \
+    COUNT=$("${DC[@]}" exec -T timescaledb \
         psql -U risk -d riskmonitor -t -c \
         "SELECT COUNT(*) FROM time_series WHERE ticker = '${corr_ticker}';" 2>/dev/null | tr -d '[:space:]')
 
@@ -208,7 +208,7 @@ done
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- Verifying correlation values are in [-1, 1] ---"
-OUT_OF_RANGE=$(${DC} exec -T timescaledb \
+OUT_OF_RANGE=$("${DC[@]}" exec -T timescaledb \
     psql -U risk -d riskmonitor -t -c \
     "SELECT COUNT(*) FROM time_series WHERE ticker LIKE 'CORR_%' AND (value < -1.0 OR value > 1.0);" 2>/dev/null | tr -d '[:space:]')
 
@@ -223,7 +223,7 @@ echo "PASS: All correlation values are in [-1, 1]"
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- Starting app service ---"
-${DC} up -d app
+"${DC[@]}" up -d app
 
 echo "--- Waiting for app service to be ready ---"
 for i in $(seq 1 90); do
@@ -233,7 +233,7 @@ for i in $(seq 1 90); do
     fi
     if [ "$i" -eq 90 ]; then
         echo "FAIL: App service did not become ready in 90 seconds" >&2
-        ${DC} logs app 2>&1 | tail -30
+        "${DC[@]}" logs app 2>&1 | tail -30
         exit 1
     fi
     sleep 1

--- a/tests/e2e-dashboard.sh
+++ b/tests/e2e-dashboard.sh
@@ -13,10 +13,11 @@ set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DC="docker compose -p frm-e2e -f ${PROJECT_DIR}/docker-compose.yml"
 
 cleanup() {
     echo "--- Cleaning up Docker services ---"
-    docker compose -f "${PROJECT_DIR}/docker-compose.yml" down -v --remove-orphans 2>/dev/null || true
+    ${DC} down -v --remove-orphans 2>/dev/null || true
 }
 trap cleanup EXIT
 
@@ -71,12 +72,12 @@ assert_contains() {
 }
 
 psql_exec() {
-    docker compose -f "${PROJECT_DIR}/docker-compose.yml" exec -T timescaledb \
+    ${DC} exec -T timescaledb \
         psql -U risk -d riskmonitor -t -c "$1" 2>/dev/null
 }
 
 psql_exec_raw() {
-    docker compose -f "${PROJECT_DIR}/docker-compose.yml" exec -T timescaledb \
+    ${DC} exec -T timescaledb \
         psql -U risk -d riskmonitor -c "$1" 2>/dev/null
 }
 
@@ -87,7 +88,7 @@ echo ""
 # 1. Start TimescaleDB
 # ---------------------------------------------------------------------------
 echo "--- Starting TimescaleDB ---"
-docker compose -f "${PROJECT_DIR}/docker-compose.yml" up -d timescaledb
+${DC} up -d timescaledb
 
 echo "--- Waiting for TimescaleDB to be healthy ---"
 for i in $(seq 1 60); do
@@ -301,7 +302,7 @@ assert_gte "Seeded news_sentiment rows" 4 "${NEWS_COUNT}"
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- Starting app service ---"
-docker compose -f "${PROJECT_DIR}/docker-compose.yml" up -d app
+${DC} up -d app
 
 echo "--- Waiting for app service to be ready ---"
 for i in $(seq 1 120); do
@@ -311,7 +312,7 @@ for i in $(seq 1 120); do
     fi
     if [ "$i" -eq 120 ]; then
         echo "FAIL: App service did not become ready in 120 seconds" >&2
-        docker compose -f "${PROJECT_DIR}/docker-compose.yml" logs app 2>&1 | tail -40
+        ${DC} logs app 2>&1 | tail -40
         exit 1
     fi
     sleep 1

--- a/tests/e2e-dashboard.sh
+++ b/tests/e2e-dashboard.sh
@@ -13,11 +13,11 @@ set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-DC="docker compose -p frm-e2e -f ${PROJECT_DIR}/docker-compose.yml"
+DC=(docker compose -p frm-e2e -f "${PROJECT_DIR}/docker-compose.yml")
 
 cleanup() {
     echo "--- Cleaning up Docker services ---"
-    ${DC} down -v --remove-orphans 2>/dev/null || true
+    "${DC[@]}" down -v --remove-orphans 2>/dev/null || true
 }
 trap cleanup EXIT
 
@@ -72,12 +72,12 @@ assert_contains() {
 }
 
 psql_exec() {
-    ${DC} exec -T timescaledb \
+    "${DC[@]}" exec -T timescaledb \
         psql -U risk -d riskmonitor -t -c "$1" 2>/dev/null
 }
 
 psql_exec_raw() {
-    ${DC} exec -T timescaledb \
+    "${DC[@]}" exec -T timescaledb \
         psql -U risk -d riskmonitor -c "$1" 2>/dev/null
 }
 
@@ -88,7 +88,7 @@ echo ""
 # 1. Start TimescaleDB
 # ---------------------------------------------------------------------------
 echo "--- Starting TimescaleDB ---"
-${DC} up -d timescaledb
+"${DC[@]}" up -d timescaledb
 
 echo "--- Waiting for TimescaleDB to be healthy ---"
 for i in $(seq 1 60); do
@@ -250,7 +250,7 @@ assert_gte "Seeded news_sentiment rows" 4 "${NEWS_COUNT}"
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- Starting app service ---"
-${DC} up -d app
+"${DC[@]}" up -d app
 
 echo "--- Waiting for app service to be ready ---"
 for i in $(seq 1 120); do
@@ -260,7 +260,7 @@ for i in $(seq 1 120); do
     fi
     if [ "$i" -eq 120 ]; then
         echo "FAIL: App service did not become ready in 120 seconds" >&2
-        ${DC} logs app 2>&1 | tail -40
+        "${DC[@]}" logs app 2>&1 | tail -40
         exit 1
     fi
     sleep 1

--- a/tests/e2e-dashboard.sh
+++ b/tests/e2e-dashboard.sh
@@ -104,59 +104,7 @@ for i in $(seq 1 60); do
 done
 
 # ---------------------------------------------------------------------------
-# 2. Create additional tables that may not be in init.sql yet
-#    (These are added by dependency branches and will be in init.sql
-#     once all stories merge to the epic branch.)
-# ---------------------------------------------------------------------------
-echo "--- Ensuring all required tables exist ---"
-
-psql_exec_raw "
-CREATE TABLE IF NOT EXISTS source_health (
-    source              TEXT PRIMARY KEY,
-    last_success        TIMESTAMPTZ,
-    last_error          TIMESTAMPTZ,
-    last_error_msg      TEXT,
-    consecutive_failures INTEGER NOT NULL DEFAULT 0
-);
-
-CREATE TABLE IF NOT EXISTS news_sentiment (
-    id          SERIAL PRIMARY KEY,
-    time        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    domain      TEXT NOT NULL,
-    headline    TEXT NOT NULL,
-    sentiment   DOUBLE PRECISION NOT NULL,
-    source_name TEXT,
-    source_url  TEXT
-);
-
-CREATE INDEX IF NOT EXISTS idx_news_sentiment_domain_time
-    ON news_sentiment (domain, time DESC);
-
-CREATE TABLE IF NOT EXISTS alert_state (
-    rule_id           TEXT PRIMARY KEY,
-    consecutive_count INTEGER NOT NULL DEFAULT 0,
-    last_triggered    TIMESTAMPTZ,
-    last_value        DOUBLE PRECISION
-);
-
-CREATE TABLE IF NOT EXISTS alert_history (
-    id           SERIAL PRIMARY KEY,
-    rule_id      TEXT NOT NULL,
-    triggered_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    value        DOUBLE PRECISION NOT NULL,
-    message      TEXT NOT NULL,
-    channels     TEXT[] NOT NULL,
-    delivered    BOOLEAN NOT NULL DEFAULT FALSE
-);
-
-CREATE INDEX IF NOT EXISTS idx_alert_history_rule_id_triggered
-    ON alert_history (rule_id, triggered_at DESC);
-"
-
-pass "All required tables created"
-
-# ---------------------------------------------------------------------------
-# 3. Seed representative data
+# 2. Seed representative data
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- Seeding time_series: composite and domain scores ---"
@@ -298,7 +246,7 @@ NEWS_COUNT=$(psql_exec "SELECT COUNT(*) FROM news_sentiment;" | tr -d '[:space:]
 assert_gte "Seeded news_sentiment rows" 4 "${NEWS_COUNT}"
 
 # ---------------------------------------------------------------------------
-# 4. Start the app service
+# 3. Start the app service
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- Starting app service ---"
@@ -319,7 +267,7 @@ for i in $(seq 1 120); do
 done
 
 # ---------------------------------------------------------------------------
-# 5. Verify: GET / returns 200 with "BOOKSTABER RISK MONITOR"
+# 4. Verify: GET / returns 200 with "BOOKSTABER RISK MONITOR"
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- Verifying dashboard page ---"
@@ -328,7 +276,7 @@ DASHBOARD_HTML=$(curl -sf http://localhost:3000)
 assert_contains "Dashboard returns HTML with title" "BOOKSTABER RISK MONITOR" "${DASHBOARD_HTML}"
 
 # ---------------------------------------------------------------------------
-# 6. Verify: GET /api/risk/scores
+# 5. Verify: GET /api/risk/scores
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- Verifying GET /api/risk/scores ---"
@@ -359,7 +307,7 @@ for domain in private_credit ai_concentration energy_geo contagion; do
 done
 
 # ---------------------------------------------------------------------------
-# 7. Verify: GET /api/risk/correlations
+# 6. Verify: GET /api/risk/correlations
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- Verifying GET /api/risk/correlations ---"
@@ -377,7 +325,7 @@ done
 pass "All 3 correlation pairs present"
 
 # ---------------------------------------------------------------------------
-# 8. Verify: GET /api/risk/health
+# 7. Verify: GET /api/risk/health
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- Verifying GET /api/risk/health ---"
@@ -397,7 +345,7 @@ for src in fred finnhub; do
 done
 
 # ---------------------------------------------------------------------------
-# 9. Verify: GET /api/risk/news
+# 8. Verify: GET /api/risk/news
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- Verifying GET /api/risk/news ---"
@@ -419,7 +367,7 @@ for domain in private_credit ai_concentration energy_geo contagion; do
 done
 
 # ---------------------------------------------------------------------------
-# 10. Verify: GET /api/risk/freshness
+# 9. Verify: GET /api/risk/freshness
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- Verifying GET /api/risk/freshness ---"
@@ -442,7 +390,7 @@ fi
 pass "OWL freshness status: ${OWL_STATUS}"
 
 # ---------------------------------------------------------------------------
-# 11. Verify: GET /api/risk/alerts
+# 10. Verify: GET /api/risk/alerts
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- Verifying GET /api/risk/alerts ---"
@@ -460,7 +408,7 @@ ALERTS_LEN=$(echo "${ALERTS_RESPONSE}" | jq '.alerts | length')
 pass "Alerts array length: ${ALERTS_LEN} (empty is valid)"
 
 # ---------------------------------------------------------------------------
-# 12. Smoke test: dashboard HTML structural elements
+# 11. Smoke test: dashboard HTML structural elements
 # ---------------------------------------------------------------------------
 echo ""
 echo "--- Smoke testing dashboard HTML structure ---"


### PR DESCRIPTION
## Summary

- Add `-p frm-e2e` Compose project name to all 3 E2E scripts so test stacks never collide with a running dev stack
- Remove dead `CREATE TABLE IF NOT EXISTS` DDL from `e2e-dashboard.sh` (all tables defined in `init.sql` since dependency branches merged)
- Reuse the correlation service `.venv` in `e2e-alerting.sh` instead of creating a disposable temp venv on every run

Partially addresses #42 -- these are targeted improvements to the existing bash E2E tests rather than the full testcontainers migration originally proposed. The issue description assumed the scripts could be replaced with testcontainers, but they test multi-service orchestration (app, correlation service, webhook receivers) that requires Docker Compose.

## Test plan

- [x] All 3 scripts pass `bash -n` syntax check
- [ ] `./tests/e2e-alerting.sh` runs successfully with isolated project name
- [ ] `./tests/e2e-correlation.sh` runs successfully with isolated project name
- [ ] `./tests/e2e-dashboard.sh` runs successfully without inline DDL